### PR TITLE
Add PLATFORM_ARCHITECTURE var, set to "k8s"

### DIFF
--- a/src/config/default/spinnaker.yml
+++ b/src/config/default/spinnaker.yml
@@ -10,6 +10,7 @@
 global:
   spinnaker:
     timezone: 'America/Los_Angeles'
+    architecture: ${PLATFORM_ARCHITECTURE}
 
 services:
   default:

--- a/src/manifests/init-env.json
+++ b/src/manifests/init-env.json
@@ -20,6 +20,7 @@
     "ECHO_OPTS": "-Dspring.profiles.active=armory,local",
     "SPRING_PROFILES_ACTIVE": "armory,local",
     "SPINNAKER_AWS_ENABLED": "false",
-    "CONFIGURATOR_ENABLED": "true"
+    "CONFIGURATOR_ENABLED": "true",
+    "PLATFORM_ARCHITECTURE": "k8s"
   }
 }


### PR DESCRIPTION
Also in spinnaker.yml, global.spinnaker.architecture.  Intended to help
identify the architecture spinnaker is installed on (k8s for kubernetes,
for example) so software can work differently based on arch (ex. configurator
can use configmaps on k8s while s3 on aws).