### PR TITLE
Use downward API to self-identify namespace

### DIFF
--- a/src/manifests/lighthouse-deployment.json
+++ b/src/manifests/lighthouse-deployment.json
@@ -69,6 +69,14 @@
               {
                 "name": "LOG_LEVEL",
                 "value": "DEBUG"
+              },
+              {
+                "name": "NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
               }
             ],
             "resources": {


### PR DESCRIPTION
In lighthouse, we'll need to know the namespace to put into the k8s configmap
file; easiest way to get that is to set it as an env var in the container so
we can grab it and re-use it.  This mechanism will work even if the namespace
changes somehow.