### PR TITLE
Make binding name unique

### DIFF
--- a/src/manifests/armory-service-account.json
+++ b/src/manifests/armory-service-account.json
@@ -2,7 +2,7 @@
   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
   "kind": "ClusterRoleBinding",
   "metadata": {
-    "name": "armory-admin"
+    "name": "armory-${NAMESPACE}-admin"
   },
   "subjects": [
     {


### PR DESCRIPTION
Each time one of us runs the install script, we are overriding the same `ClusterRoleBinding`. Since the namespace is defined in the subject, only one of us has permissions at a time.