### PR TITLE
Allow users to add kubeconfig files instead of svc-accnt

### DIFF
--- a/src/config/custom/clouddriver-local.yml
+++ b/src/config/custom/clouddriver-local.yml
@@ -3,9 +3,10 @@ kubernetes:
   accounts:
     - name: kubernetes
       providerVersion: v2
-      serviceAccount: true
+      serviceAccount: ${USE_SERVICE_ACCOUNT}
       namespaces:
         - ${NAMESPACE}
+      ${KUBECONFIG_CONFIG_ENTRY}
 
 artifacts:
   s3:

--- a/src/manifests/custom-credentials.json
+++ b/src/manifests/custom-credentials.json
@@ -6,5 +6,7 @@
     "namespace": "${NAMESPACE}"
   },
   "type": "Opaque",
-  "data": {}
+  "data": {
+    ${KUBECONFIG_ENTRY_IN_SECRETS_FILE}
+  }
 }


### PR DESCRIPTION
Allow users to add their kubeconfig files instead of using service account.