### PR TITLE
feat(installer) make the installer script text/html

### DIFF
--- a/bin/public-installer-releaser.sh
+++ b/bin/public-installer-releaser.sh
@@ -34,5 +34,5 @@ envsubst "${VARS_TO_REPLACE}" < ../src/public-installer.sh > ../src/build/public
 
 if [[ ${UPLOAD_NEW_PUBLIC_INSTALLER} == 'true' ]]; then
   echo "Uploading public installer"
-  aws s3 cp --acl public-read-write ../src/build/public-installer.sh "s3://armory-web/install/release/kubernetes-installer/public-installer.sh"
+  aws s3 cp --acl public-read-write --content-type text/html ../src/build/public-installer.sh "s3://armory-web/install/release/kubernetes-installer/public-installer.sh"
 fi


### PR DESCRIPTION
This will allow users to view the script if they go to get-k8s.armory.io. It also follows the existing convention of get.armory.io