### PR TITLE
Store the original NGINX_IP as BASE_IP env var

### DIFF
--- a/src/manifests/init-env.json
+++ b/src/manifests/init-env.json
@@ -16,6 +16,7 @@
     "REDIS_HOST": "redis",
     "API_HOST": "http://${NGINX_IP}/api",
     "DECK_HOST": "http://${NGINX_IP}",
+    "BASE_IP": "${NGINX_IP}",
     "AUTH_ENABLED": "false",
     "SERVER_ADDRESS": "0.0.0.0",
     "CLOUDDRIVER_OPTS": "-Dspring.profiles.active=armory,local",


### PR DESCRIPTION
...so we might be able to reference it again without having to parse the
API_HOST or DECK_HOST strings.