### PR TITLE
fix(jenkins) we have to fetch edge version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,9 @@ node {
     stage('Fetch latest Armory version') {
       sh("""
       ./bin/fetch-latest-armory-version.sh
-      cp src/build/armoryspinnaker-jenkins-version.manifest src/version.manifest   # pin to an edge version
+      mv src/version.manifest src/build/pinned-version.manifest
+      cp src/build/armoryspinnaker-jenkins-version.manifest src/version.manifest   # use edge as base pin
+      cat src/build/pinned-version.manifest >> src/version.manifest   # apply any pins on top
     """)
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,15 @@ properties(
 node {
   checkout scm
 
+  if (params.ARMORYSPINNAKER_JENKINS_JOB_ID != '') {
+    stage('Fetch latest Armory version') {
+      sh("""
+      ./bin/fetch-latest-armory-version.sh
+      cp src/build/armoryspinnaker-jenkins-version.manifest src/version.manifest   # pin to an edge version
+    """)
+    }
+  }
+
   stage('Testing') {
     def runner = { testName ->
       return {


### PR DESCRIPTION
If an edge version is provided, it needs to be fetched and pinned in the src/version.manifest.
Integration tests run in a container, which doesn't have access to `arm`.

- [x] Tested with Jenkins replay on http://jenkins.armory.io/job/armory/job/k8s-installer/job/master/166/console using edge versions.