### PR TITLE
ENG-1918 reuse config

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -503,7 +503,7 @@ function remove_k8s_configmaps() {
       | xargs kubectl $KUBECTL_OPTIONS delete cm
   else
     echo "Deleting default config maps and secrets if they exist"
-    kubectl $KUBECTL_OPTIONS get cm default-config init-env -o=custom-columns=NAME:.metadata.name  \
+    kubectl $KUBECTL_OPTIONS get cm default-config -o=custom-columns=NAME:.metadata.name  \
       | tail -n +2 \
       | xargs kubectl $KUBECTL_OPTIONS delete cm
   fi


### PR DESCRIPTION
What this does:

For one, it directly puts the pipeline into cloud storage, bypassing gate, et al (although it still has to wait for it, because front50 may have issues if it can't initialize properly).  It specifically sets the ID of the pipeline to "update-spinnaker" (which is neat, because editing the pipeline ends up at a URL like "/#/applications/armory/executions/configure/update-spinnaker").

For two, when running again, it checks to see if the namespace already has a custom-config configmap defined, and if so, asks if the user wants to keep it.  If they do, the install script skips doing any pushing of deployment changes, instead just updating the default configmap, secrets, and the pipeline, and then directs the user to deploy with Spinnaker to get the new versions released.

This is a stopgap solution that should work for some of our existing technology partners who will need to be able to upgrade their installs sooner than later, but aren't averse to keyboard jockey interfaces.