### PR TITLE
fix(lb): support aws internal loadbalancers

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -1291,6 +1291,14 @@ EOF
   else
     save_response SERVICE_TYPE "LoadBalancer"
   fi
+
+  # using internal load balancers requires extra info for AWS
+  # https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws.go#L102
+  if [[ "${LB_TYPE}" == "Internal" ]]; then
+    save_response LB_INTERNAL "true"
+  else
+    save_response LB_INTERNAL "false"
+  fi
 }
 
 function save_response() {

--- a/src/manifests/nginx-svc.json
+++ b/src/manifests/nginx-svc.json
@@ -8,7 +8,8 @@
             "app": "nginx"
         },
         "annotations": {
-            "cloud.google.com/load-balancer-type": "${LB_TYPE}"
+            "cloud.google.com/load-balancer-type": "${LB_TYPE}",
+            "service.beta.kubernetes.io/aws-load-balancer-internal": "${LB_INTERNAL}"
         }
     },
     "spec": {


### PR DESCRIPTION
one of our customers is installing on AWS where they use private
subnets. public elbs cannot be attached to private subnets so we need to
be explicit about using an internal elb