### PR TITLE
fix(install): use wide output

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -450,11 +450,11 @@ function create_k8s_nginx_load_balancer() {
     #we use loopback because we create a tunnel later
     export NGINX_IP="127.0.0.1"
   else
-    local IP=$(kubectl ${KUBECTL_OPTIONS} get services | grep nginx | awk '{ print $4 }')
+    local IP=$(kubectl ${KUBECTL_OPTIONS} get services nginx --no-headers -o wide | awk '{ print $4 }')
     echo -n "Waiting for load balancer to receive an IP..."
     while [ "$IP" == "<pending>" ] || [ -z "$IP" ]; do
       sleep 5
-      local IP=$(kubectl ${KUBECTL_OPTIONS} get services | grep nginx | awk '{ print $4 }')
+      local IP=$(kubectl ${KUBECTL_OPTIONS} get services nginx --no-headers -o wide | awk '{ print $4 }')
       echo -n "."
     done
     echo "Found IP $IP"


### PR DESCRIPTION
use the wide output for nginx ip since aws ingress names are much longer
than the default column length