### PR TITLE
Revert "enable diag data by default"

### DIFF
--- a/src/config/default/echo-armory.yml
+++ b/src/config/default/echo-armory.yml
@@ -1,3 +1,6 @@
-diagnostics:
+rest:
   enabled: true
-  id:${ARMORY_ID:unknown}
+  endpoints:
+    - url: "https://debug.armory.io"
+      headers:
+        Authorization: Armory ${ARMORY_ID:unknown}


### PR DESCRIPTION
Reverts armory-io/k8s-installer#195 and armory-io/k8s-installer#196