### PR TITLE
Set the architecture in the YAML configs.

### DIFF
--- a/src/config/default/spinnaker-armory.yml
+++ b/src/config/default/spinnaker-armory.yml
@@ -1,3 +1,6 @@
+armory:
+  architecture: 'k8s'
+
 features:
   artifacts:
     enabled: true


### PR DESCRIPTION
This is arguably redundant with the env var PLATFORM_ARCHITECTURE, but Deck
needs it in here.  Was going to make this attempt to reference the env var,
but this config is (currently) bound to the k8s install anyway.