### PR TITLE
fix(deployments): add docker reg override for lib

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -10,7 +10,7 @@ export CONTINUE_FILE=/tmp/armory.env
 export ARMORY_CONF_STORE_PREFIX=front50
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io/armory}
 export LATEST_VERSION_MANIFEST_URL="https://s3-us-west-2.amazonaws.com/armory-web/install/release/armoryspinnaker-latest-version.manifest"
-
+export LIBRARY_DOCKER_REGISTRY=${LIBRARY_DOCKER_REGISTRY:-docker.io/library}
 # Start from a fresh build dir
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"

--- a/src/manifests/nginx-deployment.json
+++ b/src/manifests/nginx-deployment.json
@@ -56,7 +56,7 @@
               }
             },
             "name": "armory-nginx",
-            "image": "nginx",
+            "image": "${LIBRARY_DOCKER_REGISTRY}/nginx",
             "command": [
               "bash",
               "-c"

--- a/src/manifests/redis.json
+++ b/src/manifests/redis.json
@@ -46,7 +46,7 @@
         "containers": [
           {
             "name": "armory-redis",
-            "image": "redis",
+            "image": "${LIBRARY_DOCKER_REGISTRY}/redis",
             "resources": {
               "requests": {
                 "cpu": "${REDIS_CPU}",


### PR DESCRIPTION
add docker registry override for library images. this allows you to
install armory with images stored in a private registy vs public
dockerhub