### PR TITLE
feat(version-manifest) support offline installs using src/version.manifest

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -75,7 +75,7 @@ function fetch_latest_version_manifest() {
       echo "Fetching latest stable to src/build/version.manifest..."
       source build/armoryspinnaker-latest-version.manifest
 
-      curl -sS "${armoryspinnaker_version_manifest_url}" > build/version.manifest || true
+      curl -sS "${armoryspinnaker_version_manifest_url}" > build/version.manifest
     fi
   fi
 


### PR DESCRIPTION
test by hand:
- [x] online with nothing in version.manifest, should not append anything to `build/version.manifest`
- [x] online with something in version.manifest, should append versions to `build/version.manifest`
- [x] offline with nothing in version.manifest, should append versions to `build/version.manifest`
- [x] offline with something in version.manifest, should append versions to `build/version.manifest`